### PR TITLE
Adds xcuserdatad to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+xcuserdata


### PR DESCRIPTION
With the new submodule layout, it shows dirty repositories when Xcode changes xcuserdatad, which is local data anyways. We generally exclude that directory from git.