### PR TITLE
Fix section insertion order

### DIFF
--- a/Mojave/DataSourceMutable.swift
+++ b/Mojave/DataSourceMutable.swift
@@ -50,9 +50,13 @@ struct DataSourceChangesetModification: DataSourceMutable {
             sections.remove(at: sectionIndex)
         }
         
+        // insert sections
         var newSections = [DataSourceSection]()
         var newSectionIndicies = IndexSet()
-        changeset.insertedSections.forEach {
+        let sortedInsertedSections = changeset.insertedSections.sorted {
+            $0.key < $1.key
+        }
+        sortedInsertedSections.forEach {
             newSectionIndicies.append(IndexSet(integer: $0.key))
             newSections.append($0.value)
         }


### PR DESCRIPTION
Insertion order is important so we must sort our insection section hash table before iterating over it.